### PR TITLE
feat(task): implement task name editing with modal form

### DIFF
--- a/src/components/Task/TaskEdit.vue
+++ b/src/components/Task/TaskEdit.vue
@@ -1,0 +1,110 @@
+<template>
+	<section class="task-edit">
+		<h3 class="task-edit__title">
+			Edit task
+		</h3>
+		<div class="task-edit__content">
+			<article class="task-edit__item">
+				<label class="task-edit__subtitle">
+					Task name
+				</label>
+				<input
+					v-model="taskCopy.name"
+					class="task-edit__field"
+					type="text"
+				>
+			</article>
+
+			<UIButton
+				class="task-edit__button-save button--bg-color-3"
+				@button-click="editTaskName(task);"
+			>
+				<span class="button__icon">
+					<i class="icon">
+						<FontAwesomeIcon icon="edit" />
+					</i>
+				</span>
+				<span>
+					Save
+				</span>
+			</UIButton>
+		</div>
+	</section>
+</template>
+
+<script>
+	import {mapActions} from 'vuex';
+	import UIButton from '@/components/UI/UIButton.vue';
+
+	export default {
+		name: 'TaskEdit',
+		components: {
+			UIButton
+		},
+		props: {
+			task: {
+				type: Object,
+				required: true
+			}
+		},
+		data() {
+			return {
+				taskCopy: this.task
+			};
+		},
+		methods: {
+			...mapActions(['updateTask']),
+			editTaskName(task) {
+				this.updateTask(task);
+			}
+		}
+	};
+</script>
+
+<style lang="scss" scoped>
+	.task-edit {
+		&__title {
+			font-size: 2.8rem;
+			font-weight: bold;
+			margin-bottom: 2rem;
+		}
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+		}
+
+		&__item {
+			display: flex;
+			flex-direction: column;
+
+			>* {
+				&:not(:last-child) {
+					margin-bottom: 1.2rem;
+				}
+			}
+		}
+
+		&__subtitle {
+			font-size: 1.8rem;
+			margin-bottom: 1rem;
+		}
+
+		&__field {
+			padding: 1.2rem;
+			font-size: 1.5rem;
+			border-radius: 0.5rem;
+			border: 0.2rem solid $color-brand-3;
+			background-color: $color-white;
+			overflow: hidden;
+		}
+
+
+		&__button-save {
+			max-width: 10rem;
+			margin-top: 2rem;
+			align-self: flex-end;
+		}
+	}
+</style>

--- a/src/components/Task/TaskEdit.vue
+++ b/src/components/Task/TaskEdit.vue
@@ -17,7 +17,7 @@
 
 			<UIButton
 				class="task-edit__button-save button--bg-color-3"
-				@button-click="editTaskName(task);"
+				@button-click="editTaskName(task); emitTaskEditClose();"
 			>
 				<span class="button__icon">
 					<i class="icon">
@@ -56,6 +56,9 @@
 			...mapActions(['updateTask']),
 			editTaskName(task) {
 				this.updateTask(task);
+			},
+			emitTaskEditClose() {
+				this.$emit('task-edit-close');
 			}
 		}
 	};

--- a/src/components/Task/TaskPreview.vue
+++ b/src/components/Task/TaskPreview.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		class="task-preview"
-		:class="{ 'is-done': taskItem.status.done }"
+		:class="{ 'is-done': taskItem.status.done, 'is-show': taskItem.status.show }"
 	>
 		<UIButton
 			class="task-preview__button-done button--icon"
@@ -20,16 +20,26 @@
 		</div>
 		<ul class="task-preview__tools">
 			<li>
-				<UIButton
-					class="task-preview__button-edit button--icon"
-					@button-click="editTaskName(taskItem)"
+				<UIModal
+					:class="{ 'is-open': taskItem.status.show }"
+					@modal-close="hideTask(taskItem)"
 				>
-					<span class="button__icon">
-						<i class="icon">
-							<FontAwesomeIcon icon="edit" />
-						</i>
-					</span>
-				</UIButton>
+					<template #modalButtonOpen>
+						<UIButton
+							class="task-preview__button-edit button--icon"
+							@button-click="showTask(taskItem); editTaskName(taskItem);"
+						>
+							<span class="button__icon">
+								<i class="icon">
+									<FontAwesomeIcon icon="edit" />
+								</i>
+							</span>
+						</UIButton>
+					</template>
+					<template #modalInner>
+						{{ taskItem.name }}
+					</template>
+				</UIModal>
 			</li>
 			<li>
 				<UIButton
@@ -50,11 +60,13 @@
 <script>
 	import {mapActions} from 'vuex';
 	import UIButton from '@/components/UI/UIButton.vue';
+	import UIModal from '@/components/UI/UIModal.vue';
 
 	export default {
 		name: 'TaskPreview',
 		components: {
-			UIButton
+			UIButton,
+			UIModal
 		},
 		props: {
 			taskItem: {
@@ -71,6 +83,14 @@
 				task.status.done = !task.status.done;
 				this.updateTask(task);
 			},
+			showTask(task) {
+				task.status.show = true;
+				this.updateTask(task);
+			},
+			hideTask(task) {
+				task.status.show = false;
+				this.updateTask(task);
+			},
 			editTaskName(task) {
 				alert('Edit task name');
 
@@ -83,7 +103,6 @@
 <style lang="scss" scoped>
 	.task-preview {
 		padding: 1rem;
-		position: relative;
 		display: flex;
 		align-items: center;
 		line-height: 1;
@@ -130,10 +149,7 @@
 		}
 
 		&__tools {
-			position: absolute;
-			top: 50%;
-			right: 1rem;
-			transform: translateY(-50%);
+			margin-left: auto;
 			display: flex;
 			list-style: none;
 			opacity: 0;
@@ -143,12 +159,12 @@
 					margin-right: 1.2rem;
 				}
 			}
-
-			:deep(.button) {
-				font-size: 2rem;
-			}
 		}
 
+		&__button-edit,
+		&__button-remove {
+			font-size: 2rem;
+		}
 
 		&__button-edit {
 			color: $color-brand-3;
@@ -193,6 +209,14 @@
 					&:hover {
 						color: mix($color-black, $color-success, 20%);
 					}
+				}
+			}
+		}
+
+		&.is-show {
+			.task-preview {
+				&__tools {
+					opacity: 1;
 				}
 			}
 		}

--- a/src/components/Task/TaskPreview.vue
+++ b/src/components/Task/TaskPreview.vue
@@ -20,7 +20,10 @@
 		</div>
 		<ul class="task-preview__tools">
 			<li>
-				<UIButton class="task-preview__button-edit button--icon">
+				<UIButton
+					class="task-preview__button-edit button--icon"
+					@button-click="editTaskName(taskItem)"
+				>
 					<span class="button__icon">
 						<i class="icon">
 							<FontAwesomeIcon icon="edit" />
@@ -66,6 +69,11 @@
 			]),
 			changeTaskDone(task) {
 				task.status.done = !task.status.done;
+				this.updateTask(task);
+			},
+			editTaskName(task) {
+				alert('Edit task name');
+
 				this.updateTask(task);
 			}
 		}

--- a/src/components/Task/TaskPreview.vue
+++ b/src/components/Task/TaskPreview.vue
@@ -18,16 +18,29 @@
 				{{ taskItem.name }}
 			</p>
 		</div>
-		<UIButton
-			class="task-preview__button-remove button--icon"
-			@button-click="removeTask(taskItem.id)"
-		>
-			<span class="button__icon">
-				<i class="icon">
-					<FontAwesomeIcon icon="trash" />
-				</i>
-			</span>
-		</UIButton>
+		<ul class="task-preview__tools">
+			<li>
+				<UIButton class="task-preview__button-edit button--icon">
+					<span class="button__icon">
+						<i class="icon">
+							<FontAwesomeIcon icon="edit" />
+						</i>
+					</span>
+				</UIButton>
+			</li>
+			<li>
+				<UIButton
+					class="task-preview__button-remove button--icon"
+					@button-click="removeTask(taskItem.id)"
+				>
+					<span class="button__icon">
+						<i class="icon">
+							<FontAwesomeIcon icon="trash" />
+						</i>
+					</span>
+				</UIButton>
+			</li>
+		</ul>
 	</div>
 </template>
 
@@ -62,6 +75,7 @@
 <style lang="scss" scoped>
 	.task-preview {
 		padding: 1rem;
+		position: relative;
 		display: flex;
 		align-items: center;
 		line-height: 1;
@@ -107,11 +121,37 @@
 			}
 		}
 
-		&__button-remove {
-			margin-left: auto;
-			color: $color-error;
-			font-size: 2rem;
+		&__tools {
+			position: absolute;
+			top: 50%;
+			right: 1rem;
+			transform: translateY(-50%);
+			display: flex;
+			list-style: none;
 			opacity: 0;
+
+			>* {
+				&:not(:last-child) {
+					margin-right: 1.2rem;
+				}
+			}
+
+			:deep(.button) {
+				font-size: 2rem;
+			}
+		}
+
+
+		&__button-edit {
+			color: $color-brand-3;
+
+			&:hover {
+				color: mix($color-black, $color-brand-3, 20%);
+			}
+		}
+
+		&__button-remove {
+			color: $color-error;
 
 			&:hover {
 				color: mix($color-black, $color-error, 20%);
@@ -122,7 +162,7 @@
 			background-color: $color-ghost;
 
 			.task-preview {
-				&__button-remove {
+				&__tools {
 					opacity: 1;
 					cursor: pointer;
 				}

--- a/src/components/Task/TaskPreview.vue
+++ b/src/components/Task/TaskPreview.vue
@@ -37,7 +37,10 @@
 						</UIButton>
 					</template>
 					<template #modalInner>
-						<TaskEdit :task="taskItem" />
+						<TaskEdit
+							:task="taskItem"
+							@task-edit-close="hideTask(taskItem)"
+						/>
 					</template>
 				</UIModal>
 			</li>

--- a/src/components/Task/TaskPreview.vue
+++ b/src/components/Task/TaskPreview.vue
@@ -27,7 +27,7 @@
 					<template #modalButtonOpen>
 						<UIButton
 							class="task-preview__button-edit button--icon"
-							@button-click="showTask(taskItem); editTaskName(taskItem);"
+							@button-click="showTask(taskItem);"
 						>
 							<span class="button__icon">
 								<i class="icon">
@@ -37,7 +37,7 @@
 						</UIButton>
 					</template>
 					<template #modalInner>
-						{{ taskItem.name }}
+						<TaskEdit :task="taskItem" />
 					</template>
 				</UIModal>
 			</li>
@@ -61,12 +61,14 @@
 	import {mapActions} from 'vuex';
 	import UIButton from '@/components/UI/UIButton.vue';
 	import UIModal from '@/components/UI/UIModal.vue';
+	import TaskEdit from '@/components/Task/TaskEdit.vue';
 
 	export default {
 		name: 'TaskPreview',
 		components: {
 			UIButton,
-			UIModal
+			UIModal,
+			TaskEdit
 		},
 		props: {
 			taskItem: {
@@ -89,11 +91,6 @@
 			},
 			hideTask(task) {
 				task.status.show = false;
-				this.updateTask(task);
-			},
-			editTaskName(task) {
-				alert('Edit task name');
-
 				this.updateTask(task);
 			}
 		}

--- a/src/components/UI/UIModal.vue
+++ b/src/components/UI/UIModal.vue
@@ -1,0 +1,81 @@
+<template>
+	<div class="modal">
+		<slot name="modalButtonOpen" />
+		<div class="modal__overlay">
+			<div class="modal__box">
+				<UIButton
+					class="modal__button-close button--line-black button--small"
+					@button-click="emitCloseModal()"
+				>
+					<span class="button__icon">
+						<i class="icon">
+							<FontAwesomeIcon icon="times" />
+						</i>
+					</span>
+				</UIButton>
+				<slot name="modalInner" />
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+	import UIButton from '@/components/UI/UIButton.vue';
+
+	export default {
+		name: 'UIModal',
+		components: {
+			UIButton
+		},
+		methods: {
+			emitCloseModal() {
+				this.$emit('modal-close');
+			}
+		}
+	};
+</script>
+
+<style lang="scss" scoped>
+	.modal {
+		&__overlay {
+			width: 100%;
+			height: 100%;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			position: fixed;
+			top: 0;
+			left: 0;
+			z-index: 999999;
+			background: rgba($color-black, 0.7);
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		&__button-close {
+			position: absolute;
+			top: 1rem;
+			right: 1rem;
+			border-radius: 50%;
+		}
+
+		&__box {
+			width: 100%;
+			max-width: 40rem;
+			padding: 3rem;
+			position: relative;
+			font-size: 1.6rem;
+			border-radius: 0.5rem;
+			background-color: $color-white;
+		}
+
+		&.is-open {
+			.modal {
+				&__overlay {
+					opacity: 1;
+					pointer-events: all;
+				}
+			}
+		}
+	}
+</style>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 
 import {library} from '@fortawesome/fontawesome-svg-core';
 import {
+	faEdit,
 	faTrash,
 	faCheckCircle,
 	faPlusCircle,
@@ -10,6 +11,6 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 
-library.add(faTrash, faCheckCircle, faPlusCircle, faTimes, faInfo);
+library.add(faEdit, faTrash, faCheckCircle, faPlusCircle, faTimes, faInfo);
 
 Vue.component('FontAwesomeIcon', FontAwesomeIcon);

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -11,21 +11,24 @@ const state = {
 				id: 1,
 				name: 'Do something awesome!',
 				status: {
-					done: false
+					done: false,
+					show: false
 				}
 			},
 			{
 				id: 2,
 				name: 'Buy toilet paper',
 				status: {
-					done: false
+					done: false,
+					show: false
 				}
 			},
 			{
 				id: 3,
 				name: 'Learn Vue',
 				status: {
-					done: false
+					done: false,
+					show: false
 				}
 			}
 		]

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -56,7 +56,8 @@ const actions = {
 			id: task.id,
 			name: task.name,
 			status: {
-				done: false
+				done: false,
+				show: false
 			}
 		};
 		commit('addTask', taskNew);


### PR DESCRIPTION
# feat(task): implement task name editing with modal form

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | S | 10-08-2022 | 11-08-2022 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
|  | <img width="400" alt="Edit icon added to task item" src="https://user-images.githubusercontent.com/14045148/183872431-fa58bde1-a3a4-4506-8461-7ae6cedc2dfe.png" /><img width="400" alt="Task name editing with modal form" src="https://user-images.githubusercontent.com/14045148/184053959-7f2ed253-2ac3-43d1-acc0-e6bae9b40cab.png" /> |

## 🔄 Type of Change

- [ ] Bug fix
- [ ] Breaking change
- [ ] Dependency
- [x] New feature
- [ ] Improvement
- [ ] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

- Add an [icon](https://fontawesome.com/icons/pen-to-square?s=solid) for the button that will edit the task.

## 📋 Changes Made

## 🧪 Tests

- [x] Verify edit icon appears on each task item
- [x] Verify clicking edit opens modal form with current task name
- [x] Verify task name updates correctly after editing

## 🔗 References

### Documentation
- https://fontawesome.com/icons/pen-to-square?s=solid
