### PR TITLE
fix(deps): add overrides to reduce security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue-todolist",
-	"version": "3.7.6",
+	"version": "3.7.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue-todolist",
-			"version": "3.7.6",
+			"version": "3.7.7",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1885,19 +1885,6 @@
 				"node": ">=v18"
 			}
 		},
-		"node_modules/@commitlint/is-ignored/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@commitlint/lint": {
 			"version": "20.0.0",
 			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.0.0.tgz",
@@ -2345,6 +2332,28 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/@inquirer/external-editor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+			"integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.1.1",
+				"iconv-lite": "^0.7.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@jest/schemas": {
 			"version": "29.6.3",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -2481,6 +2490,126 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@jsonjoy.com/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/buffers": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+			"integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/codegen": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+			"integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pack": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+			"integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/base64": "^1.1.2",
+				"@jsonjoy.com/buffers": "^1.2.0",
+				"@jsonjoy.com/codegen": "^1.0.0",
+				"@jsonjoy.com/json-pointer": "^1.0.2",
+				"@jsonjoy.com/util": "^1.9.0",
+				"hyperdyperid": "^1.2.0",
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pointer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+			"integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/codegen": "^1.0.0",
+				"@jsonjoy.com/util": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/util": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+			"integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/buffers": "^1.0.0",
+				"@jsonjoy.com/codegen": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
 			}
 		},
 		"node_modules/@keyv/serialize": {
@@ -3170,19 +3299,6 @@
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
-			"integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"@types/qs": "*",
-				"@types/range-parser": "*",
-				"@types/send": "*"
-			}
-		},
-		"node_modules/@types/express/node_modules/@types/express-serve-static-core": {
 			"version": "4.19.7",
 			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.7.tgz",
 			"integrity": "sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==",
@@ -3316,9 +3432,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+			"integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3530,19 +3646,6 @@
 				"vue": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@vue/babel-preset-app/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@vue/babel-preset-jsx": {
@@ -3964,16 +4067,6 @@
 				"node": ">=4.8"
 			}
 		},
-		"node_modules/@vue/cli-shared-utils/node_modules/cross-spawn/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
 		"node_modules/@vue/cli-shared-utils/node_modules/execa": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -4050,19 +4143,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/@vue/cli-shared-utils/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@vue/cli-shared-utils/node_modules/shebang-command": {
@@ -4218,31 +4298,6 @@
 			"dependencies": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
-			}
-		},
-		"node_modules/@vue/component-compiler-utils/node_modules/picocolors": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@vue/component-compiler-utils/node_modules/postcss": {
-			"version": "7.0.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"picocolors": "^0.2.1",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
 			}
 		},
 		"node_modules/@vue/component-compiler-utils/node_modules/prettier": {
@@ -5069,6 +5124,19 @@
 				"ms": "2.0.0"
 			}
 		},
+		"node_modules/body-parser/node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/body-parser/node_modules/ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -5183,6 +5251,22 @@
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
@@ -5393,9 +5477,9 @@
 			}
 		},
 		"node_modules/chardet": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+			"integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5736,16 +5820,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/clipboardy/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver"
 			}
 		},
 		"node_modules/clipboardy/node_modules/shebang-command": {
@@ -6277,19 +6351,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/conventional-changelog-core/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/conventional-changelog-core/node_modules/type-fest": {
 			"version": "4.41.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -6383,19 +6444,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-writer/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/conventional-changelog/node_modules/conventional-changelog-angular": {
@@ -6664,19 +6712,6 @@
 				"is-core-module": "^2.5.0",
 				"semver": "^7.3.4",
 				"validate-npm-package-license": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/conventional-recommended-bump/node_modules/normalize-package-data/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
 			},
 			"engines": {
 				"node": ">=10"
@@ -6982,19 +7017,6 @@
 				"webpack": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/css-loader/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/css-minimizer-webpack-plugin": {
@@ -7508,6 +7530,36 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/default-browser": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
+			"integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+			"integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/default-gateway": {
@@ -8284,19 +8336,6 @@
 				"eslint": ">=6.0.0"
 			}
 		},
-		"node_modules/eslint-compat-utils/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/eslint-config-prettier": {
 			"version": "10.1.8",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
@@ -8423,19 +8462,6 @@
 				"@typescript-eslint/parser": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/eslint-plugin-vue/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -8966,21 +8992,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/external-editor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chardet": "^0.7.0",
-				"iconv-lite": "^0.4.24",
-				"tmp": "^0.0.33"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9352,13 +9363,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/fs-monkey": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
-			"integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
-			"dev": true,
-			"license": "Unlicense"
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -9720,19 +9724,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/git-semver-tags/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/gitconfiglocal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
@@ -9783,6 +9774,23 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/glob-to-regex.js": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+			"integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
 			}
 		},
 		"node_modules/glob-to-regexp": {
@@ -10161,23 +10169,6 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
-		"node_modules/html-entities": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
-			"integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/mdevils"
-				},
-				{
-					"type": "patreon",
-					"url": "https://patreon.com/mdevils"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -10386,17 +10377,31 @@
 				"url": "https://github.com/sponsors/typicode"
 			}
 		},
+		"node_modules/hyperdyperid": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+			"integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.18"
+			}
+		},
 		"node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+			"integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/icss-utils": {
@@ -10551,17 +10556,17 @@
 			}
 		},
 		"node_modules/inquirer": {
-			"version": "8.2.5",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
-			"integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+			"version": "8.2.7",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz",
+			"integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@inquirer/external-editor": "^1.0.0",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.1.1",
 				"cli-cursor": "^3.1.0",
 				"cli-width": "^3.0.0",
-				"external-editor": "^3.0.3",
 				"figures": "^3.0.0",
 				"lodash": "^4.17.21",
 				"mute-stream": "0.0.8",
@@ -10571,7 +10576,7 @@
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0",
 				"through": "^2.3.6",
-				"wrap-ansi": "^7.0.0"
+				"wrap-ansi": "^6.0.1"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -10644,6 +10649,21 @@
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/inquirer/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
 			},
 			"engines": {
 				"node": ">=8"
@@ -10773,6 +10793,41 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container/node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-interactive": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -10781,6 +10836,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-network-error": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
+			"integrity": "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-number": {
@@ -11178,19 +11246,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/jsonc-eslint-parser/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/jsonfile": {
@@ -12028,16 +12083,22 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-			"integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.51.0.tgz",
+			"integrity": "sha512-4zngfkVM/GpIhC8YazOsM6E8hoB33NP0BCESPOA6z7qaL6umPJNqkO8CNYaLV2FB2MV6H1O3x2luHHOSqppv+A==",
 			"dev": true,
-			"license": "Unlicense",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"fs-monkey": "^1.0.4"
+				"@jsonjoy.com/json-pack": "^1.11.0",
+				"@jsonjoy.com/util": "^1.9.0",
+				"glob-to-regex.js": "^1.0.1",
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.0.3",
+				"tslib": "^2.0.0"
 			},
-			"engines": {
-				"node": ">= 4.0.0"
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
 			}
 		},
 		"node_modules/meow": {
@@ -12522,19 +12583,6 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
-		"node_modules/normalize-package-data/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -12860,16 +12908,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -12913,17 +12951,21 @@
 			}
 		},
 		"node_modules/p-retry": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+			"integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/retry": "0.12.0",
+				"@types/retry": "0.12.2",
+				"is-network-error": "^1.0.0",
 				"retry": "^0.13.1"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-try": {
@@ -13422,19 +13464,6 @@
 				"parse-json": "^5.0.0",
 				"path-type": "^4.0.0",
 				"yaml": "^1.10.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/postcss-loader/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
 			},
 			"engines": {
 				"node": ">=10"
@@ -14434,6 +14463,19 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/raw-body/node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/read-package-up": {
 			"version": "11.0.0",
 			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
@@ -14631,16 +14673,6 @@
 				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
-			}
-		},
-		"node_modules/read-pkg/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver"
 			}
 		},
 		"node_modules/read-pkg/node_modules/type-fest": {
@@ -15005,6 +15037,19 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/run-applescript": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/run-async": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -15221,13 +15266,16 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/send": {
@@ -16052,16 +16100,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/standard-version/node_modules/conventional-changelog-writer/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
 		"node_modules/standard-version/node_modules/conventional-commits-filter": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
@@ -16185,16 +16223,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/standard-version/node_modules/git-semver-tags/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/standard-version/node_modules/has-flag": {
@@ -16418,16 +16446,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/standard-version/node_modules/meow/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
 		"node_modules/standard-version/node_modules/normalize-package-data": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
@@ -16629,29 +16647,6 @@
 				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
-			}
-		},
-		"node_modules/standard-version/node_modules/read-pkg/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
-		"node_modules/standard-version/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/standard-version/node_modules/split2": {
@@ -17044,19 +17039,6 @@
 			"peerDependencies": {
 				"postcss-html": "^1.0.0",
 				"stylelint": ">=14.0.0"
-			}
-		},
-		"node_modules/stylelint-config-recommended-vue/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/stylelint-config-sass-guidelines": {
@@ -17785,6 +17767,23 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/thingies": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
+			"integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "^2"
+			}
+		},
 		"node_modules/thread-loader": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-3.0.4.tgz",
@@ -17911,19 +17910,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/tmp": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"os-tmpdir": "~1.0.2"
-			},
-			"engines": {
-				"node": ">=0.6.0"
-			}
-		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -17963,6 +17949,23 @@
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/tree-dump": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+			"integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
 		},
 		"node_modules/trim-newlines": {
 			"version": "3.0.1",
@@ -18344,20 +18347,6 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/vue-eslint-parser/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/vue-hot-reload-api": {
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
@@ -18651,27 +18640,60 @@
 			}
 		},
 		"node_modules/webpack-dev-middleware": {
-			"version": "5.3.4",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-			"integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+			"integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"colorette": "^2.0.10",
-				"memfs": "^3.4.3",
-				"mime-types": "^2.1.31",
+				"memfs": "^4.43.1",
+				"mime-types": "^3.0.1",
+				"on-finished": "^2.4.1",
 				"range-parser": "^1.2.1",
 				"schema-utils": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
+				"webpack": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"webpack": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/webpack-dev-middleware/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/webpack-dev-middleware/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/webpack-dev-middleware/node_modules/schema-utils": {
@@ -18695,55 +18717,53 @@
 			}
 		},
 		"node_modules/webpack-dev-server": {
-			"version": "4.15.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
+			"integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/bonjour": "^3.5.9",
-				"@types/connect-history-api-fallback": "^1.3.5",
-				"@types/express": "^4.17.13",
-				"@types/serve-index": "^1.9.1",
-				"@types/serve-static": "^1.13.10",
-				"@types/sockjs": "^0.3.33",
-				"@types/ws": "^8.5.5",
+				"@types/bonjour": "^3.5.13",
+				"@types/connect-history-api-fallback": "^1.5.4",
+				"@types/express": "^4.17.21",
+				"@types/express-serve-static-core": "^4.17.21",
+				"@types/serve-index": "^1.9.4",
+				"@types/serve-static": "^1.15.5",
+				"@types/sockjs": "^0.3.36",
+				"@types/ws": "^8.5.10",
 				"ansi-html-community": "^0.0.8",
-				"bonjour-service": "^1.0.11",
-				"chokidar": "^3.5.3",
+				"bonjour-service": "^1.2.1",
+				"chokidar": "^3.6.0",
 				"colorette": "^2.0.10",
 				"compression": "^1.7.4",
 				"connect-history-api-fallback": "^2.0.0",
-				"default-gateway": "^6.0.3",
-				"express": "^4.17.3",
+				"express": "^4.21.2",
 				"graceful-fs": "^4.2.6",
-				"html-entities": "^2.3.2",
-				"http-proxy-middleware": "^2.0.3",
-				"ipaddr.js": "^2.0.1",
-				"launch-editor": "^2.6.0",
-				"open": "^8.0.9",
-				"p-retry": "^4.5.0",
-				"rimraf": "^3.0.2",
-				"schema-utils": "^4.0.0",
-				"selfsigned": "^2.1.1",
+				"http-proxy-middleware": "^2.0.9",
+				"ipaddr.js": "^2.1.0",
+				"launch-editor": "^2.6.1",
+				"open": "^10.0.3",
+				"p-retry": "^6.2.0",
+				"schema-utils": "^4.2.0",
+				"selfsigned": "^2.4.1",
 				"serve-index": "^1.9.1",
 				"sockjs": "^0.3.24",
 				"spdy": "^4.0.2",
-				"webpack-dev-middleware": "^5.3.4",
-				"ws": "^8.13.0"
+				"webpack-dev-middleware": "^7.4.2",
+				"ws": "^8.18.0"
 			},
 			"bin": {
 				"webpack-dev-server": "bin/webpack-dev-server.js"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.37.0 || ^5.0.0"
+				"webpack": "^5.0.0"
 			},
 			"peerDependenciesMeta": {
 				"webpack": {
@@ -18779,6 +18799,19 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/webpack-dev-server/node_modules/glob-parent": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -18790,6 +18823,25 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/open": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+			"integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"wsl-utils": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/webpack-dev-server/node_modules/readdirp": {
@@ -19071,6 +19123,38 @@
 				}
 			}
 		},
+		"node_modules/wsl-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+			"integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/wsl-utils/node_modules/is-wsl": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/xml-name-validator": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
@@ -19204,66 +19288,77 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/yorkie/node_modules/cross-spawn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-			"integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			}
-		},
 		"node_modules/yorkie/node_modules/execa": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-			"integrity": "sha512-zDWS+Rb1E8BlqqhALSt9kUhss8Qq4nN3iof3gsOdyINksElaPyNBtKUMTR62qhvgVWR0CqCX7sdnKe4MnUbFEA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
 		},
 		"node_modules/yorkie/node_modules/get-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=4"
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yorkie/node_modules/human-signals": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=16.17.0"
 			}
 		},
 		"node_modules/yorkie/node_modules/is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/yorkie/node_modules/lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+		"node_modules/yorkie/node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
 			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/yorkie/node_modules/normalize-path": {
@@ -19277,77 +19372,62 @@
 			}
 		},
 		"node_modules/yorkie/node_modules/npm-run-path": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"path-key": "^2.0.0"
+				"path-key": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yorkie/node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/yorkie/node_modules/path-key": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/yorkie/node_modules/shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^1.0.0"
+				"node": ">=12"
 			},
-			"engines": {
-				"node": ">=0.10.0"
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/yorkie/node_modules/shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+		"node_modules/yorkie/node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/yorkie/node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/yorkie/node_modules/which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
+				"node": ">=12"
 			},
-			"bin": {
-				"which": "bin/which"
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/yorkie/node_modules/yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-			"dev": true,
-			"license": "ISC"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.7.6",
+	"version": "3.7.7",
 	"private": true,
 	"name": "vue-todolist",
 	"description": "To-do list made with Vue.",

--- a/package.json
+++ b/package.json
@@ -84,5 +84,17 @@
 	"engines": {
 		"node": "20.18.0",
 		"npm": "10.8.2"
+	},
+	"overrides": {
+		"semver": "^7.6.3",
+		"tough-cookie": "^4.1.4",
+		"inquirer": "^8.2.6",
+		"webpack-dev-server": "^5.2.1",
+		"@vue/component-compiler-utils": {
+			"postcss": "^8.4.31"
+		},
+		"yorkie": {
+			"execa": "^8.0.1"
+		}
 	}
 }


### PR DESCRIPTION
# fix(deps): add overrides to reduce security vulnerabilities

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | S | 20-11-2025 | 20-11-2025 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| <img width="724" alt="Screenshot 2025-11-20 a las 19 41 39" src="https://github.com/user-attachments/assets/25b654eb-21cf-40fd-8531-24a12a0124ef" /> | <img width="724" alt="Screenshot 2025-11-20 a las 19 44 24" src="https://github.com/user-attachments/assets/bf2aaa17-d20d-4cdd-abcc-3b72e5e4bcf9" /> |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [ ] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

> [!CAUTION]
> ```bash
> $ npm audit
> 27 vulnerabilities (8 low, 15 moderate, 4 high)
> ```

- Add npm `overrides` section to `package.json` to force secure versions of transitive dependencies, reducing security vulnerabilities from 27 to 18 (33.3% reduction) and eliminating all HIGH severity issues

## 📋 Changes Made

### Dependencies
- Add `overrides` section to `package.json` with:
  - `semver`: `^7.6.3` (fixes ReDoS vulnerability)
  - `tough-cookie`: `^4.1.4` (fixes prototype pollution)
  - `inquirer`: `^8.2.6` (fixes vulnerabilities)
  - `webpack-dev-server`: `^5.2.1` (fixes source code theft)
  - `postcss`: `^8.4.31` in `@vue/component-compiler-utils` (fixes parsing error)
  - `execa`: `^8.0.1` in `yorkie` (fixes command injection)
- Update `package-lock.json` with new dependency resolutions

## 🧪 Tests

- [x] Verify vulnerability reduction:

```bash
npm audit
```
- [x] Confirm application builds without errors:

```bash
npm run build
```
- [x] Verify lint passes without errors:

```bash
npm run lint
```
- [x] Verify dev server starts successfully:

```bash
npm run serve
```
- [x] Verify no regression in existing functionality

## 📌 Notes

### Vulnerable packages
| Package | Version | Severity | Dependency chain | Advisory |
| --- | --- | --- | --- | --- |
| `semver` | `<7.6.3` | 🔴 | `@vue/cli-service` → `semver` | [GHSA-c2qf-rxjj-qqgw](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw) |
| `webpack-dev-server` | `≤5.2.0` | 🟡 | `@vue/cli-service` → `webpack-dev-server` | [GHSA-9jgg-88mc-972h](https://github.com/advisories/GHSA-9jgg-88mc-972h) |
| `postcss` | `<8.4.31` | 🟡 | `@vue/component-compiler-utils` → `postcss` | [GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) |
| `tough-cookie` | `<4.1.4` | 🟡 | `@vue/cli-service` → `jest` → `jsdom` → `tough-cookie` | [GHSA-4v9v-hfq4-rm2v](https://github.com/advisories/GHSA-4v9v-hfq4-rm2v) |
| `execa` | `<8.0.1` | 🟡 | `yorkie` → `execa` | — |
| `follow-redirects` | `<1.15.4` | 🟡 | `axios` → `follow-redirects` | [GHSA-jchw-25xp-jwwc](https://github.com/advisories/GHSA-jchw-25xp-jwwc) |
| `vue-template-compiler` | `2.7.16` | 🟡 | Direct dependency | [GHSA-5j4c-8p2g-v4jx](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx) |
| `inquirer` | `<8.2.6` | 🟢 | `@vue/cli-plugin-eslint` → `inquirer` | — |
| `vue` | `2.7.16` | 🟢 | Direct dependency | [GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx) |

### Security overrides
| Package | Version | Severity | Advisory |
| --- | --- | --- | --- |
| `semver` | `7.6.3` | 🔴 | [GHSA-c2qf-rxjj-qqgw](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw) |
| `webpack-dev-server` | `5.2.1` | 🟡 | [GHSA-9jgg-88mc-972h](https://github.com/advisories/GHSA-9jgg-88mc-972h) |
| `tough-cookie` | `4.1.4` | 🟡 | [GHSA-4v9v-hfq4-rm2v](https://github.com/advisories/GHSA-4v9v-hfq4-rm2v) |
| `postcss` | `8.4.31` | 🟡 | [GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) |
| `execa` | `8.0.1` | 🟡 | — |
| `inquirer` | `8.2.6` | 🟢 | — |

### Vulnerability reduction summary after fix
| Severity | Before | After | Reduction |
| --- | --- | --- | --- |
| 🔴 HIGH | 4 | 0 | 100% |
| 🟡 MODERATE | 15 | 10 | 33% |
| 🟢 LOW | 8 | 8 | 0% |
| **TOTAL** | **27** | **18** | **33%** |

> [!WARNING]
> ```bash
> $ npm audit
> 18 vulnerabilities (8 low, 10 moderate)
> ```

**Reduction:** 27 → 18 vulnerabilities (33% reduction)

### Remaining vulnerabilities after fix
| Package | Version | Why it can't be fixed | Advisory |
| --- | --- | --- | --- |
| `vue` | `2.7.16` | Requires `vue@3` upgrade<br>(major breaking change) | [GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx) |
| `vue-template-compiler` | `2.7.16` | Requires `vue@3` upgrade<br>(major breaking change) | [GHSA-5j4c-8p2g-v4jx](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx) |

The `vue@2` has reached End-of-Life and no longer receives security updates. The remaining 18 vulnerabilities require migration to `vue@3`.

## 🔗 References

### Documentation
- https://github.com/advisories/GHSA-jchw-25xp-jwwc
- https://github.com/advisories/GHSA-4v9v-hfq4-rm2v
- https://github.com/advisories/GHSA-9jgg-88mc-972h
- https://github.com/advisories/GHSA-7fh5-64p2-3v2j
- https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
- https://github.com/advisories/GHSA-fwmh-7hxx-r2f2
- https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides

### Related Issues
- Closes #921