### PR TITLE
hotfix(3.9.2): add missing commitlint configuration

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,42 @@
+export default {
+	"extends": [
+		"@commitlint/config-conventional",
+	],
+	"rules": {
+		"body-max-line-length": [
+			2,
+			"always",
+			10000,
+		],
+		"footer-leading-blank": [
+			0,
+			"always",
+		],
+		"footer-max-line-length": [
+			2,
+			"always",
+			10000,
+		],
+		"header-max-length": [
+			2,
+			"always",
+			150,
+		],
+		"type-enum": [
+			2,
+			"always",
+			[
+				"build",
+				"ci",
+				"docs",
+				"feat",
+				"fix",
+				"perf",
+				"refactor",
+				"revert",
+				"style",
+				"test",
+			],
+		],
+	},
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue-todolist",
-	"version": "3.9.1",
+	"version": "3.9.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue-todolist",
-			"version": "3.9.1",
+			"version": "3.9.2",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.9.1",
+	"version": "3.9.2",
 	"private": true,
 	"name": "vue-todolist",
 	"description": "To-do list made with Vue.",


### PR DESCRIPTION
# hotfix(3.9.2): add missing commitlint configuration

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P2 | XS | 23-12-2025 | 23-12-2025 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

- Add missing commitlint configuration file that was not included in the repository, causing commit message validation to fail

## 📋 Changes Made

### Configuration
- Add `commitlint.config.js` file with project-specific configuration:
  - Extends `@commitlint/config-conventional`
  - Sets `body-max-line-length` to 10000
  - Sets `footer-max-line-length` to 10000
  - Sets `header-max-length` to 150
  - Defines allowed commit types: `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`

### Version
- Bump version from `3.9.1` to `3.9.2`

## 🧪 Tests

- [x] Verify install completes without warnings:

```bash
npm install
```
- [x] Verify commitlint configuration:

```bash
npx commitlint --from HEAD~1
```
- [x] Test a commit to ensure husky hook validates the message
- [x] Verify `Prettier`, `ESLint` and `Stylelint` pass:

```bash
npm run lint
```

## 📌 Notes

The commitlint configuration was missing from the repository, which caused husky commit-msg hook to fail when validating commit messages.

## 🔗 References

### Related Issues
- Closes #959