### PR TITLE
hotfix(3.11.1): pin `eslint-plugin-vue` to exact version `10.6.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue-todolist",
-	"version": "3.11.0",
+	"version": "3.11.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue-todolist",
-			"version": "3.11.0",
+			"version": "3.11.1",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-jsonc": "^2.21.0",
 				"eslint-plugin-prettier": "^5.5.5",
-				"eslint-plugin-vue": "^10.6.2",
+				"eslint-plugin-vue": "10.6.2",
 				"eslint-webpack-plugin": "^5.0.2",
 				"husky": "^9.1.7",
 				"lint-staged": "^16.2.7",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-jsonc": "^2.21.0",
 		"eslint-plugin-prettier": "^5.5.5",
-		"eslint-plugin-vue": "^10.6.2",
+		"eslint-plugin-vue": "10.6.2",
 		"eslint-webpack-plugin": "^5.0.2",
 		"husky": "^9.1.7",
 		"lint-staged": "^16.2.7",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.11.0",
+	"version": "3.11.1",
 	"private": true,
 	"name": "vue-todolist",
 	"description": "To-do list made with Vue.",


### PR DESCRIPTION
# hotfix(3.11.1): pin `eslint-plugin-vue` to exact version `10.6.2`

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P1 | XS | 17-01-2026 | 17-01-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [x] Documentation
- [ ] CI/CD

## 📝 Summary

- Hotfix to resolve `npm install` failure caused by automatic update of `eslint-plugin-vue` to version `10.7.0`, which is incompatible with ESLint 8 legacy config format

## 📋 Changes Made

### Dependencies
- Pin `eslint-plugin-vue` to exact version `10.6.2` (remove caret `^`)

### Version
- Bump version from `3.11.0` to `3.11.1`

## 🧪 Tests

- [x] Verify install completes without errors:

```bash
npm install
```
- [x] Verify lint passes successfully:

```bash
npm run lint
```

## 📌 Notes

- The `eslint-plugin-vue@10.7.0` introduced TypeScript in build process ([#2916](https://github.com/vuejs/eslint-plugin-vue/pull/2916))
- This generates `export default` which causes error: "Unexpected top-level property default"
- Incompatible with ESLint 8 legacy config format (`.eslintrc.js`)
- Upgrading to ESLint 9 is not viable because `@vue/cli-plugin-eslint` does not support it

## 🔗 References

### Documentation
- https://github.com/vuejs/eslint-plugin-vue/pull/2916

### Related Issues
- Closes #989