### PR TITLE
hotfix(3.12.3): simplify and align ignore files to a shared minimal format

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,5 @@
 # Add below any extra paths that should not be linted.
 
 
-# FOLDERS
-.nuxt
-dist
+# Build output
+dist/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,13 +1,11 @@
-# path/to/project/root/.eslintignore
-# /node_modules/* and /bower_components/* in the project root are ignored by default
+# ESLint defaults (no need to list):
+#   - Folders excluded automatically (node_modules/)
+#   - Non-JS files (CSS, images, fonts, *.md, LICENSE, etc.)
+#   - Files with unknown or extensionless types (.gitignore, .editorconfig)
+#
+# Add below any extra paths that should not be linted.
 
 
 # FOLDERS
-.git
 .nuxt
 dist
-
-# FILES
-.gitignore
-*.md
-LICENSE

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,7 @@
 # ESLint defaults (no need to list):
-#   - Folders excluded automatically (node_modules/)
-#   - Non-JS files (CSS, images, fonts, *.md, LICENSE, etc.)
-#   - Files with unknown or extensionless types (.gitignore, .editorconfig)
+#   - Folders excluded automatically (node_modules/, .git/)
+#   - Files with unknown or extensionless types (.gitignore, LICENSE, .editorconfig)
+#   - Non-JS files (CSS, images, fonts, *.md, etc.)
 #
 # Add below any extra paths that should not be linted.
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,25 @@
+# Dependencies
+node_modules/
+
+# OS
 .DS_Store
-node_modules
-/dist
+Thumbs.db
 
-# local env files
+# Logs
+*.log
+log/
+
+# Cache
+.npm
+.eslintcache
+.stylelintcache
+
+# Env
+.env
 .env.local
-.env.*.local
 
-# Log files
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
+# Build output
+dist/
 
-# Editor directories and files
-.idea
-.vscode
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
+# Tests
+coverage/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,11 +1,11 @@
-# path/to/project/root/.prettierrc
-# /node_modules/* and /bower_components/* in the project root are ignored by default
+# Prettier defaults (no need to list):
+#   - Folders excluded automatically (node_modules/, .git/)
+#   - Files with unknown or extensionless types (.gitignore, LICENSE, .editorconfig)
+#   - Binary files (images, fonts, etc.)
+#
+# Add below any extra paths that should not be formatted.
 
 
 # FOLDERS
-.git
 .nuxt
 dist
-
-# FILES
-.gitignore

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,7 @@
 # Prettier defaults (no need to list):
 #   - Folders excluded automatically (node_modules/, .git/)
 #   - Files with unknown or extensionless types (.gitignore, LICENSE, .editorconfig)
-#   - Binary files (images, fonts, etc.)
+#   - Non-formattable files (images, fonts, etc.)
 #
 # Add below any extra paths that should not be formatted.
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,5 @@
 # Add below any extra paths that should not be formatted.
 
 
-# FOLDERS
-.nuxt
-dist
+# Build output
+dist/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,7 +1,7 @@
 # Stylelint defaults (no need to list):
-#   - Folders excluded automatically (node_modules/)
-#   - Non-CSS files (JS, images, fonts, etc.)
+#   - Folders excluded automatically (node_modules/, .git/)
 #   - Files with unknown or extensionless types (.gitignore, LICENSE, .editorconfig)
+#   - Non-CSS files (JS, images, fonts, etc.)
 #
 # Add below any extra paths that should not be linted.
 

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -6,5 +6,5 @@
 # Add below any extra paths that should not be linted.
 
 
-# FOLDERS
-dist
+# Build output
+dist/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,10 +1,10 @@
-# path/to/project/root/.stylelint.config.js
-# /node_modules/* and /bower_components/* in the project root are ignored by default
+# Stylelint defaults (no need to list):
+#   - Folders excluded automatically (node_modules/)
+#   - Non-CSS files (JS, images, fonts, etc.)
+#   - Files with unknown or extensionless types (.gitignore, LICENSE, .editorconfig)
+#
+# Add below any extra paths that should not be linted.
 
 
 # FOLDERS
-.git
 dist
-
-# FILES
-.gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.12.3](https://github.com/beatrizsmerino/vue-todolist/compare/3.12.2...3.12.3) (2026-04-17)
+
+
+### Refactor
+
+* **eslintignore:** restructure entries under 'Build output' block ([7a99ca3](https://github.com/beatrizsmerino/vue-todolist/commit/7a99ca37b23eb5618b701fcb7a891b263256f5f8)), closes [#1120](https://github.com/beatrizsmerino/vue-todolist/issues/1120)
+* **eslintignore:** update header and remove entries already ignored by default ([1715bae](https://github.com/beatrizsmerino/vue-todolist/commit/1715baeb13486550cb8a8aed341b889ff1f416e7)), closes [#1120](https://github.com/beatrizsmerino/vue-todolist/issues/1120)
+* **gitignore:** simplify to minimum viable ignore rules ([40ab821](https://github.com/beatrizsmerino/vue-todolist/commit/40ab8216e15ef634501c7042c4033eda4c381283)), closes [#1117](https://github.com/beatrizsmerino/vue-todolist/issues/1117)
+* **ignores:** unify header structure across `.prettierignore`, `.eslintignore` and `.stylelintignore` ([c81aede](https://github.com/beatrizsmerino/vue-todolist/commit/c81aedebddc9eaadf6c5f12cc99af1a1170914a6)), closes [#1118](https://github.com/beatrizsmerino/vue-todolist/issues/1118) [#1119](https://github.com/beatrizsmerino/vue-todolist/issues/1119) [#1120](https://github.com/beatrizsmerino/vue-todolist/issues/1120)
+* **prettierignore:** restructure entries under 'Build output' block ([ea09066](https://github.com/beatrizsmerino/vue-todolist/commit/ea09066ae9d36812ade3ece6609755c4e87f1f19)), closes [#1118](https://github.com/beatrizsmerino/vue-todolist/issues/1118)
+* **prettierignore:** update header and remove entries already ignored by default ([0fac7d6](https://github.com/beatrizsmerino/vue-todolist/commit/0fac7d678e9b6c49cf44eaa70d293bac8f8ad19e)), closes [#1118](https://github.com/beatrizsmerino/vue-todolist/issues/1118)
+* **stylelintignore:** restructure entries under 'Build output' block ([f391e3d](https://github.com/beatrizsmerino/vue-todolist/commit/f391e3dd25e4aa158ae0c60b0554e30a44b14719)), closes [#1119](https://github.com/beatrizsmerino/vue-todolist/issues/1119)
+* **stylelintignore:** update header and remove entries already ignored by default ([ba2b2ce](https://github.com/beatrizsmerino/vue-todolist/commit/ba2b2cefd46326e43db84d8463264c79c769635b)), closes [#1119](https://github.com/beatrizsmerino/vue-todolist/issues/1119)
+
+### Build
+
+* **package:** bump version from `3.12.2` to `3.12.3` ([8af7ec4](https://github.com/beatrizsmerino/vue-todolist/commit/8af7ec463ee46741dcc0e0c1e0efffcd5ea6be07))
+* **deps-dev:** update `prettier` from `3.8.1` to `3.8.3` ([4860693](https://github.com/beatrizsmerino/vue-todolist/commit/48606932c49e0eb7aac721554ba6b58eec917e37))
+
 ## [3.12.2](https://github.com/beatrizsmerino/vue-todolist/compare/3.12.1...3.12.2) (2026-04-12)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue-todolist",
-	"version": "3.12.2",
+	"version": "3.12.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue-todolist",
-			"version": "3.12.2",
+			"version": "3.12.3",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.12.2",
+	"version": "3.12.3",
 	"private": true,
 	"name": "vue-todolist",
 	"description": "To-do list made with Vue.",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"commitizen": "^4.3.1",
 		"conventional-changelog-cli": "^5.0.0",
 		"cz-conventional-changelog": "^3.3.0",
-		"prettier": "^3.8.1",
+		"prettier": "^3.8.3",
 		"standard-version": "^9.5.0"
 	},
 	"engines": {


### PR DESCRIPTION
# hotfix(3.12.3): simplify and align ignore files to a shared minimal format

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 4h | P0 | M | 17-04-2026 | 17-04-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change
- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [x] Documentation
- [x] CI/CD

## 📝 Summary

- Hotfix release that simplifies `.gitignore`, `.prettierignore`, `.eslintignore` and `.stylelintignore` to a shared minimal format with a unified header structure, updates the `prettier` devDependency and regenerates the `CHANGELOG.md`

## 📋 Changes Made

### Configuration

#### `.gitignore`
- Simplify to minimum viable ignore rules

#### `.prettierignore`
- Update header and remove entries already ignored by default
- Restructure entries under `# Build output` block

#### `.eslintignore`
- Update header and remove entries already ignored by default
- Restructure entries under `# Build output` block

#### `.stylelintignore`
- Update header and remove entries already ignored by default
- Restructure entries under `# Build output` block

#### Header unification
- Unify header structure across `.prettierignore`, `.eslintignore` and `.stylelintignore`

### Dependencies
- Update `prettier` devDependency from `3.8.1` to `3.8.3`

### CI/CD
- Regenerate `CHANGELOG.md` with the new `3.12.3` section

### Version
- Bump version from `3.12.2` to `3.12.3`

## 🧪 Tests
- [x] Verify linting passes with no errors and ignored folders are respected:

```bash
npm run lint
```

## 🔗 References

### Related Issues
- Closes #1117
- Closes #1118
- Closes #1119
- Closes #1120