### PR TITLE
hotfix(3.12.6): pin `globalDependencies` install to `devDependencies` version

### DIFF
--- a/bin/preinstall-global-dependencies.js
+++ b/bin/preinstall-global-dependencies.js
@@ -143,7 +143,7 @@ const installGlobalDeps = () => {
 		depVersion,
 	]) => {
 		if (depName && depVersion) {
-			execSync(`${getCommandInstallDeps()} ${depName}@${getCleanVersion(depVersion)}`);
+			execSync(`${getCommandInstallDeps()} ${depName}@${getCleanVersion(depVersion).slice(1)}`);
 			logDeps.push({
 				"Status": `➕`,
 				"Name": depName,

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
 	},
 	"globalDependencies": {
 		"@vue/cli": "^5.0.9",
-		"@commitlint/cli": "^20.5.0",
-		"@commitlint/config-conventional": "^20.5.0",
+		"@commitlint/cli": "^21.0.0",
+		"@commitlint/config-conventional": "^21.0.0",
 		"commitizen": "^4.3.1",
 		"conventional-changelog-cli": "^5.0.0",
 		"cz-conventional-changelog": "^3.3.0",


### PR DESCRIPTION
# hotfix(3.12.6): pin `globalDependencies` install to `devDependencies` version

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P0 | XS | 18-05-2026 | 18-05-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change
- [x] Bug fix
- [ ] Breaking change
- [ ] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary
- `bin/preinstall-global-dependencies.js` invoked `npm i -g <pkg>@^X.Y.Z`, passing the caret prefix straight to `npm`. `npm` resolved the caret as a range and installed the latest matching version, and `syncGlobalDeps` then wrote that drifted version back to `globalDependencies`. Strip the `^` prefix at the install site so the global install pins the exact version declared in `devDependencies`.
- Align `globalDependencies` entries for `@commitlint/cli` and `@commitlint/config-conventional` with the versions declared in `devDependencies` (`^21.0.0`).

## 📋 Changes Made

### Bug Fixes
- `bin/preinstall-global-dependencies.js` now strips the `^` prefix when invoking `npm i -g` by chaining `.slice(1)` on the result of `getCleanVersion`, forcing `npm` to install the exact version declared in `devDependencies`

### Configuration
- Update `globalDependencies` entries for `@commitlint/cli` and `@commitlint/config-conventional` from `^20.5.0` to `^21.0.0` to match `devDependencies`

## 🧪 Tests
- [x] `globalDependencies` ends with the same caret range as `devDependencies` (`^21.0.0` ↔ `^21.0.0`)
- [x] Installed global versions match `devDependencies` exactly (`21.0.0`):

```bash
npm list -g --depth 0 --json
```
- [x] Lint passes:

```bash
npm run lint
```

## 📌 Notes
- The `.slice(1)` workaround leans on the current implementation of `getCleanVersion` (which always returns a string starting with `^`). The follow-up refactor in #1184 replaces this chain with a dedicated `stripVersionPrefix` helper

## 🔗 References

### Related Issues
- Closes #1182
- #1183
- #1184
- #1185
- #1186